### PR TITLE
Add support for OpenAI's newer speech-to-text models: gpt-4o-transcribe and gpt-4o-mini-transcribe

### DIFF
--- a/llm_whisper_api.py
+++ b/llm_whisper_api.py
@@ -2,6 +2,7 @@ import click
 import httpx
 import io
 import llm
+from pathlib import Path
 
 
 @llm.hookimpl
@@ -29,22 +30,25 @@ def register_commands(cli):
         # Read the entire content into memory first
         audio_content = audio_file.read()
         audio_file.close()
+        audio_stream = io.BytesIO(audio_content)
+        suffix = Path(audio_file.name).suffix
+        audio_stream.name = f"audio{suffix}"  # OpenAI API requires a filename, or 400 error
 
         key = llm.get_key(api_key, "openai")
         if not key:
             raise click.ClickException("OpenAI API key is required")
         try:
-            click.echo(transcribe(audio_content, key, model))
+            click.echo(transcribe(audio_stream, key, model))
         except httpx.HTTPError as ex:
             raise click.ClickException(str(ex))
 
 
-def transcribe(audio_content: bytes, api_key: str, model: str) -> str:
+def transcribe(audio_stream: io.BytesIO, api_key: str, model: str) -> str:
     """
     Transcribe audio content using OpenAI's Whisper API.
 
     Args:
-        audio_content (bytes): The audio content as bytes
+        audio_stream (io.BytesIO): The audio content as stream
         api_key (str): OpenAI API key
         model (str): The model name to use for transcription
 
@@ -57,10 +61,7 @@ def transcribe(audio_content: bytes, api_key: str, model: str) -> str:
     url = "https://api.openai.com/v1/audio/transcriptions"
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    audio_file = io.BytesIO(audio_content)
-    audio_file.name = "audio.mp3"  # OpenAI API requires a filename, or 400 error
-
-    files = {"file": audio_file}
+    files = {"file": audio_stream}
     data = {"model": model, "response_format": "json"}
 
     with httpx.Client() as client:

--- a/llm_whisper_api.py
+++ b/llm_whisper_api.py
@@ -9,7 +9,13 @@ def register_commands(cli):
     @cli.command()
     @click.argument("audio_file", type=click.File("rb"))
     @click.option("api_key", "--key", help="API key to use")
-    def whisper_api(audio_file, api_key):
+    @click.option(
+        "-m", "--model",
+        type=click.Choice(["whisper-1", "gpt-4o-transcribe", "gpt-4o-mini-transcribe"]),
+        default="whisper-1",
+        help="Model to use for transcription",
+    )
+    def whisper_api(audio_file, api_key, model):
         """
         Run transcriptions using the OpenAI Whisper API
 
@@ -18,6 +24,7 @@ def register_commands(cli):
         \b
             llm whisper-api audio.mp3 > output.txt
             cat audio.mp3 | llm whisper-api - > output.txt
+            llm whisper-api -m gpt-4o-transcribe audio.mp3 > output.txt
         """
         # Read the entire content into memory first
         audio_content = audio_file.read()
@@ -27,18 +34,19 @@ def register_commands(cli):
         if not key:
             raise click.ClickException("OpenAI API key is required")
         try:
-            click.echo(transcribe(audio_content, key))
+            click.echo(transcribe(audio_content, key, model))
         except httpx.HTTPError as ex:
             raise click.ClickException(str(ex))
 
 
-def transcribe(audio_content: bytes, api_key: str) -> str:
+def transcribe(audio_content: bytes, api_key: str, model: str) -> str:
     """
     Transcribe audio content using OpenAI's Whisper API.
 
     Args:
         audio_content (bytes): The audio content as bytes
         api_key (str): OpenAI API key
+        model (str): The model name to use for transcription
 
     Returns:
         str: The transcribed text
@@ -53,7 +61,7 @@ def transcribe(audio_content: bytes, api_key: str) -> str:
     audio_file.name = "audio.mp3"  # OpenAI API requires a filename, or 400 error
 
     files = {"file": audio_file}
-    data = {"model": "whisper-1", "response_format": "text"}
+    data = {"model": model, "response_format": "text"}
 
     with httpx.Client() as client:
         response = client.post(url, headers=headers, files=files, data=data)

--- a/llm_whisper_api.py
+++ b/llm_whisper_api.py
@@ -69,7 +69,7 @@ def transcribe(audio_stream: io.BytesIO, api_key: str, model: str) -> str:
     files = {"file": audio_stream}
     data = {"model": model, "response_format": "json"}
 
-    with httpx.Client() as client:
+    with httpx.Client(timeout=httpx.Timeout(5.0, read=180.0)) as client:
         response = client.post(url, headers=headers, files=files, data=data)
         response.raise_for_status()
         return response.json()["text"].strip()

--- a/llm_whisper_api.py
+++ b/llm_whisper_api.py
@@ -27,12 +27,7 @@ def register_commands(cli):
             cat audio.mp3 | llm whisper-api - > output.txt
             llm whisper-api -m gpt-4o-transcribe audio.mp3 > output.txt
         """
-        # Read the entire content into memory first
-        audio_content = audio_file.read()
-        audio_file.close()
-        audio_stream = io.BytesIO(audio_content)
-        suffix = Path(audio_file.name).suffix
-        audio_stream.name = f"audio{suffix}"  # OpenAI API requires a filename, or 400 error
+        audio_stream = load_audio(audio_file)
 
         key = llm.get_key(api_key, "openai")
         if not key:
@@ -41,6 +36,16 @@ def register_commands(cli):
             click.echo(transcribe(audio_stream, key, model))
         except httpx.HTTPError as ex:
             raise click.ClickException(str(ex))
+
+
+def load_audio(audio_file) -> io.BytesIO:
+    # Read the entire content into memory first
+    audio_content = audio_file.read()
+    audio_file.close()
+    audio_stream = io.BytesIO(audio_content)
+    suffix = Path(audio_file.name).suffix
+    audio_stream.name = f"audio{suffix}"  # OpenAI API requires a filename, or 400 error
+    return audio_stream
 
 
 def transcribe(audio_stream: io.BytesIO, api_key: str, model: str) -> str:

--- a/llm_whisper_api.py
+++ b/llm_whisper_api.py
@@ -61,9 +61,9 @@ def transcribe(audio_content: bytes, api_key: str, model: str) -> str:
     audio_file.name = "audio.mp3"  # OpenAI API requires a filename, or 400 error
 
     files = {"file": audio_file}
-    data = {"model": model, "response_format": "text"}
+    data = {"model": model, "response_format": "json"}
 
     with httpx.Client() as client:
         response = client.post(url, headers=headers, files=files, data=data)
         response.raise_for_status()
-        return response.text.strip()
+        return response.json()["text"].strip()

--- a/tests/test_whisper_api.py
+++ b/tests/test_whisper_api.py
@@ -8,7 +8,7 @@ def test_whisper_api(httpx_mock):
         url="https://api.openai.com/v1/audio/transcriptions",
         method="POST",
         status_code=200,
-        text=expected_text,
+        json={"text": expected_text},
     )
     runner = CliRunner()
     with runner.isolated_filesystem():


### PR DESCRIPTION
This PR adds support for OpenAI's newer speech-to-text models (`gpt-4o-transcribe` and `gpt-4o-mini-transcribe`) in addition to the existing `whisper-1` model.

```bash
uvx --with git+https://github.com/ftnext/simonw-llm-whisper-api.git@support-other-transcribe-models llm whisper-api -m gpt-4o-transcribe --key $OPENAI_API_KEY audio.wav 
```

Based on my experience with SpeechRecognition ([v3.14.2](https://github.com/Uberi/speech_recognition/releases/tag/3.14.2)), it seems straightforward to add support for gpt-4o-transcribe and gpt-4o-mini-transcribe to current implementation with the [Create transcription](https://platform.openai.com/docs/api-reference/audio/createTranscription) endpoint.

### Changes

1. Modified the `transcribe` function to accept a `model` parameter, allowing users to specify which model to use
2. Updated the API request handling to accommodate the constraints of the newer models:
   - Changed the default response format to "json" (newer models support json format only)
       - https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-response_format
   - Fixed file extension handling to use the original file extension instead of always using `.mp3`
3. Updated tests to properly mock the JSON response format

### How it works

Users can now specify the model using the `-m` or `--model` option:

```bash
llm whisper-api -m gpt-4o-transcribe --key $OPENAI_API_KEY audio.wav
```

If no model is specified, it defaults to the original `whisper-1` model for backward compatibility.